### PR TITLE
Fix: Use only nameservers declared in network range

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ dnsmasq__pid_file: "/var/run/proxy.dnsmasq.pid"
 
 dnsmasq__neg_ttl: 5
 dnsmasq__enabled: True
+dnsmasq__network: 0.0.0.0/0

--- a/templates/etc_resolv_conf_dnsmasq
+++ b/templates/etc_resolv_conf_dnsmasq
@@ -1,5 +1,7 @@
 {% if 'nameserver' in groups %}
 {%   for dns in groups['nameserver'] %}
-nameserver {{ hostvars[dns]['ansible_default_ipv4']['address'] }}
+{%     if hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) %}
+nameserver {{ hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) }}
+{%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Sometimes, outside network are unreachable, so we need locally
accessibles nameservers only