### PR TITLE
Feat: Use ansible.utils new names for Trixie version

### DIFF
--- a/templates/dnsmasq_conf
+++ b/templates/dnsmasq_conf
@@ -12,8 +12,8 @@ dns-forward-max={{ dnsmasq__forward_max }}
 {% endif %}
 {% if 'nameserver' in groups %}
 {%   for dns in groups['nameserver'] %}
-{%     if hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) %}
-server={{ hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) }}
+{%     if hostvars[dns]['ansible_default_ipv4']['address']|ansible.utils.ipaddr(dnsmasq__network) %}
+server={{ hostvars[dns]['ansible_default_ipv4']['address']|ansible.utils.ipaddr(dnsmasq__network) }}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/templates/etc_resolv_conf_dnsmasq
+++ b/templates/etc_resolv_conf_dnsmasq
@@ -1,7 +1,7 @@
 {% if 'nameserver' in groups %}
 {%   for dns in groups['nameserver'] %}
-{%     if hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) %}
-nameserver {{ hostvars[dns]['ansible_default_ipv4']['address']|ipaddr(dnsmasq__network) }}
+{%     if hostvars[dns]['ansible_default_ipv4']['address']|ansible.utils.ipaddr(dnsmasq__network) %}
+nameserver {{ hostvars[dns]['ansible_default_ipv4']['address']|ansible.utils.ipaddr(dnsmasq__network) }}
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
- ipaddr filter is now known as ansible.utils.ipaddr